### PR TITLE
Remove deprecated sections

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,4 +47,6 @@
           "market_metrics_api_examples"
         ]
       }
+    ]
+  }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -46,18 +46,5 @@
           "market_metrics_api_tables",
           "market_metrics_api_examples"
         ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Adding Adapters",
-        "ids": [
-          "market_adapter_listing_overview",
-          "market_adapter_listing_owner",
-          "market_adapter_listing_open_adapter"
-        ]
-      },
-      "market_keybase_verification",
-      "market_api_keys"
-    ]
-  }
+      }
 }


### PR DESCRIPTION
Since adding your own adapter, keybase and the old API keys are no longer supported, I'm killing it